### PR TITLE
Pin pytest to 8.3 due to compatibility issues with pytest-factoryboy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ deps =
     lint: pylint>=3.0.0
     lint: pydocstyle
     lint: pycodestyle
+    tests,functests: pytest<8.4
     lint,tests: pytest-mock
     lint,tests,functests: pytest
     lint,tests,functests: h-testkit


### PR DESCRIPTION
See: 
 - https://github.com/pytest-dev/pytest-factoryboy/issues/232