### PR TITLE
Unpin pytest

### DIFF
--- a/.cookiecutter/includes/tox/deps
+++ b/.cookiecutter/includes/tox/deps
@@ -1,1 +1,1 @@
-tests,functests: pytest<8.4
+tests,functests: pytest

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     lint,tests,functests: h-matchers
     lint,template: cookiecutter
     typecheck: mypy
-    tests,functests: pytest<8.4
+    tests,functests: pytest
 depends =
     coverage: tests,py{311,310,39}-tests
 commands =


### PR DESCRIPTION
The issue with pytest-factoryboy compatibility is now fixed, see:
https://github.com/pytest-dev/pytest-factoryboy/pull/233
